### PR TITLE
Fix Safari ordered list marker for 3-digit numbers

### DIFF
--- a/ja/for-novices/videos2025.html
+++ b/ja/for-novices/videos2025.html
@@ -59,6 +59,11 @@
             
         }
 
+        #sequential ol {
+            list-style-position: inside;
+            padding-left: 0;
+        }
+
         #category {
             margin-left: 24px;
             width: 75%;


### PR DESCRIPTION
Safariで#100超のol番号がoverflow領域でクリップされ2桁表示になるため、#sequential olにlist-style-position: insideを適用